### PR TITLE
sequelize version upに伴うaffected rowsの挙動維持対応

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -25,6 +25,11 @@ class SequelizeContainer {
         charset: 'utf8mb4',
         collate: 'utf8mb4_unicode_ci',
         ssl: db_config.ssl ? 'Amazon RDS': false,
+        // v3.28.0 から updateのaffected_rowsの挙動が変わっていて、
+        // 値の変更がない場合に0が返ってくるため、その挙動をOFFにする。
+        // https://github.com/sequelize/sequelize/issues/7184
+        // https://github.com/sequelize/sequelize/pull/7423/files
+        flags: '',
       },
     });
     container[ident].table = {}; // sequelizeのテーブルオブジェクトを保持


### PR DESCRIPTION
#### 概要
sequelize version 3.28 以降で同一の値でupdateした際にaffected rows が0になってしまうので挙動維持のためflagsに空文字を挿入しました。

 - https://github.com/sequelize/sequelize/blob/v3.35.1/changelog.md

#### 関連issue
 - https://github.com/sequelize/sequelize/pull/6963 が本来の修正
 - https://github.com/sequelize/sequelize/issues/7184 がそれに伴う挙動変化の報告
 - https://github.com/sequelize/sequelize/pull/7423/files で挙動維持のためのテスト追加