### PR TITLE
コネクションプールの設定変更

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -10,8 +10,8 @@ class SequelizeContainer {
     container[ident] = new Sequelize(db_config.database, db_config.user, db_config.password, {
       host: db_config.host || process.env.MYSQL_PORT_3306_TCP_ADDR || 'mysql',
       pool: {
-        maxConnections: 10,
-        maxIdleTime: 30
+        maxConnections: db_config.pool_max_connections || 10,
+        maxIdleTime: db_config.pool_max_idle_time || 30000,
       },
       retry: {
         match: [

--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -1,18 +1,17 @@
 const Sequelize = (process.env.SEQUELIZE4 ? require('sequelize4') : require('sequelize'));
 
-let container = {};
+const container = {};
+
 class SequelizeContainer {
   static get(db_config) {
-    let ident = String(db_config.host) + ':' + String(db_config.database);
+    const ident = String(db_config.host) + ':' + String(db_config.database);
     if (container[ident]) {
       return container[ident];
     }
-    container[ident] = new Sequelize(db_config.database, db_config.user, db_config.password, {
+
+    const options = {
       host: db_config.host || process.env.MYSQL_PORT_3306_TCP_ADDR || 'mysql',
-      pool: {
-        maxConnections: db_config.pool_max_connections || 10,
-        maxIdleTime: db_config.pool_max_idle_time || 30000,
-      },
+      pool: {},
       retry: {
         match: [
           /getaddrinfo EAI_AGAIN/
@@ -31,8 +30,24 @@ class SequelizeContainer {
         // https://github.com/sequelize/sequelize/pull/7423/files
         flags: '',
       },
-    });
+    };
+
+    if (process.env.SEQUELIZE4) {
+      options.pool = {
+        max: db_config.pool_max_connections || 10,
+        idle: db_config.pool_max_idle_time || 30000,
+      };
+    } else {
+      options.pool = {
+        maxConnections: db_config.pool_max_connections || 10,
+        maxIdleTime: db_config.pool_max_idle_time || 30000,
+      };
+    }
+
+    container[ident] = new Sequelize(db_config.database, db_config.user, db_config.password, options);
+
     container[ident].table = {}; // sequelizeのテーブルオブジェクトを保持
+
     return container[ident];
   }
 }


### PR DESCRIPTION
## 概要

maxIdleTime の指定値はミリ秒ですが、30ms だと短すぎるため、
デフォルトを30秒に変更しつつ config で値を変更できるようにします。

また、 sequelize の v4 で pool のオプションが変わるのでその対応をしました。

[Tutorial | Sequelize | The node.js ORM for PostgreSQL, MySQL, SQLite and MSSQL](https://sequelize.org/v4/manual/tutorial/upgrade-to-v4.html#config-options)

## テスト

- [x] `SHOW PROCESSLIST;` でコネクションが maxIdleTime ミリ秒の間残っていることを確認