### PR TITLE
集計関数の結果が数値で返ってくるようオプションを追加

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -29,6 +29,10 @@ class SequelizeContainer {
         // https://github.com/sequelize/sequelize/issues/7184
         // https://github.com/sequelize/sequelize/pull/7423/files
         flags: '',
+        // v4からSUMなどの集計関数の結果が文字列で返ってきてしまうため、
+        // 従来通り数値で返ってくるようにする
+        // @see https://github.com/sequelize/sequelize/issues/8019#issuecomment-319014433
+        decimalNumbers: true,
       },
     };
 


### PR DESCRIPTION
## 概要

sequelize v4 からSUMなどの集計関数の結果が文字列で返ってきてしまうため、
数値で返ってくるようオプションを追加します。