### PR TITLE
読み込みが完了したテーブルのディレクトリと association を保持する

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -100,7 +100,14 @@ class SequelizeContainer {
 
     container[ident] = new Sequelize(db_config.database, db_config.user, db_config.password, options);
 
-    container[ident].table = {}; // sequelizeのテーブルオブジェクトを保持
+    // sequelizeのテーブルオブジェクトを保持
+    container[ident].table = {};
+
+    // 読み込みが完了しているテーブル定義のディレクトリ
+    container[ident].loaded_dir = {};
+
+    // 読み込みが完了していないassociation
+    container[ident].association = new Map();
 
     return container[ident];
   }


### PR DESCRIPTION
## 概要

読み込みが完了したテーブルのディレクトリを SequelizeContainer で保持し、ディスクI/Oを減らします。

また、読込が完了していない association を保持して ContactTable を読み込んでいるが、
ScheduleTable を読み込んでいない状態などにも対応できるようにします。