### PR TITLE
SequelizeContainer.getConnection でも loaded_dir と association を含める

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -131,7 +131,15 @@ class SequelizeContainer {
   static getConnection(db_config) {
     const options = SequelizeContainer._getOption(db_config);
     const ret = new Sequelize(db_config.database, db_config.user, db_config.password, options);
-    ret.table = {}; // sequelizeのテーブルオブジェクトを保持
+
+    // sequelizeのテーブルオブジェクトを保持
+    ret.table = {};
+
+    // 読み込みが完了しているテーブル定義のディレクトリ
+    ret.loaded_dir = {};
+
+    // 読み込みが完了していないassociation
+    ret.association = new Map();
 
     return ret;
   }


### PR DESCRIPTION
## 概要

#7 で SequelizeContainer.getConnection の経路の考慮が漏れていたので、
SequelizeContainer.getConnection を呼び出した場合も loaded_dir と association を含めるようにします。