### PR TITLE
collate オプションを削除

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -65,7 +65,6 @@ class SequelizeContainer {
       benchmark: !!(db_config.logging || process.env.VERBOSE),
       dialectOptions: {
         charset: 'utf8mb4',
-        collate: 'utf8mb4_unicode_ci',
         ssl: db_config.ssl ? 'Amazon RDS': false,
         // v3.28.0 から updateのaffected_rowsの挙動が変わっていて、
         // 値の変更がない場合に0が返ってくるため、その挙動をOFFにする。


### PR DESCRIPTION
## 概要

```
Ignoring invalid configuration option passed to Connection: collate. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
```

とのことなので、 collate オプションを削除します。