### PR TITLE
SQLite使用時にVERBOSE環境変数でloggingを有効にできるように修正

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -58,7 +58,7 @@ class SequelizeContainer {
       // unittest の DB は SQLite を使用
       host = 'localhost';
       dialect = 'sqlite';
-      logging = false;
+      logging = process.env.VERBOSE ? console.log : false;
     } else if (dbConfig.host_slave && isSlave) {
       host = dbConfig.host_slave;
     }


### PR DESCRIPTION
## Summary
- SQLite使用時（unittest時）に`VERBOSE`環境変数が設定されている場合、loggingが有効になるように修正
- 従来はSQLite使用時は常に`logging = false`だったため、デバッグ時にSQLログが確認できなかった

## Test plan
- [ ] `VERBOSE=1`を設定してunittestを実行し、SQLログが出力されることを確認
- [ ] `VERBOSE`未設定でunittestを実行し、SQLログが出力されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)