### PR TITLE
dialectOptionsにmaxPreparedStatementsを追加

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -87,6 +87,8 @@ class SequelizeContainer {
         // 従来通り数値で返ってくるようにする
         // @see https://github.com/sequelize/sequelize/issues/8019#issuecomment-319014433
         decimalNumbers: true,
+        // @see https://github.com/sequelize/sequelize/issues/10832#issuecomment-523089771
+        maxPreparedStatements: 300,
       },
       pool: {
         max: dbConfig.max ?? 20, // 利用者数が多い事務所は20に設定する


### PR DESCRIPTION
## Summary
- `dialectOptions`に`maxPreparedStatements: 300`を追加
- prepared statementのキャッシュ上限を設定し、メモリ使用量を制御する

## References
- https://github.com/sequelize/sequelize/issues/10832#issuecomment-523089771

## Test plan
- [ ] アプリケーションが正常に起動・動作することを確認
- [ ] DB接続が問題なく行えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)