### PR TITLE
dialectOptionsのmaxPreparedStatementsをdbConfigで上書き可能にする

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -87,7 +87,6 @@ class SequelizeContainer {
         // 従来通り数値で返ってくるようにする
         // @see https://github.com/sequelize/sequelize/issues/8019#issuecomment-319014433
         decimalNumbers: true,
-        // CPU負荷軽減のためプリペアドステートメント数を制限する
         // dbConfig.maxPreparedStatements で環境ごとに調整可能（未設定時は 300）
         // @see https://github.com/sequelize/sequelize/issues/10832#issuecomment-523089771
         maxPreparedStatements: dbConfig.maxPreparedStatements ?? 300,

--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -87,6 +87,10 @@ class SequelizeContainer {
         // 従来通り数値で返ってくるようにする
         // @see https://github.com/sequelize/sequelize/issues/8019#issuecomment-319014433
         decimalNumbers: true,
+        // CPU負荷軽減のためプリペアドステートメント数を制限する
+        // dbConfig.maxPreparedStatements で環境ごとに調整可能（未設定時は 300）
+        // @see https://github.com/sequelize/sequelize/issues/10832#issuecomment-523089771
+        maxPreparedStatements: dbConfig.maxPreparedStatements ?? 300,
       },
       pool: {
         max: dbConfig.max ?? 20, // 利用者数が多い事務所は20に設定する


### PR DESCRIPTION
## Summary

- `#24` でrevertされた `maxPreparedStatements` の設定を再追加
- 固定値（300）ではなく、`dbConfig.maxPreparedStatements` が設定されている場合はその値を優先するように変更
- 設定がない場合はデフォルト値（300）を使用

## 背景

`#23` の修正（`maxPreparedStatements: 300` を固定値で追加）は、一部の環境でCPU負荷や処理性能が低下する問題があったため `#24` でrevertされた。
本PRでは環境ごとに `dbConfig.maxPreparedStatements` で値を調整できるようにすることで、各環境に合わせた設定を可能にする。

## Test plan

- [ ] `dbConfig.maxPreparedStatements` を指定した場合、その値が `dialectOptions.maxPreparedStatements` に反映されることを確認
- [ ] `dbConfig.maxPreparedStatements` を未指定の場合、デフォルト値 `300` が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)