### PR TITLE
Fix slave ident flag when host_slave is absent

### DIFF
--- a/sequelize_container.js
+++ b/sequelize_container.js
@@ -47,7 +47,7 @@ class SequelizeContainer {
   }
 
   static getIdent(conf, isSlave) {
-    return `${ conf.host }:${ conf.database }:${ isSlave ? '1' : '0' }`;
+    return `${ conf.host }:${ conf.database }:${ conf.host_slave && isSlave ? '1' : '0' }`;
   }
 
   static _getOption(dbConfig, isSlave) {


### PR DESCRIPTION
## Summary
- update `getIdent` to set the slave flag only when `host_slave` is configured and the slave connection is requested
- keep master-only configurations on the `:0` identifier path

## Testing
- not run